### PR TITLE
Allow player addition when game is ready to start

### DIFF
--- a/app/models/domain/game.py
+++ b/app/models/domain/game.py
@@ -95,7 +95,7 @@ class GameAggregate:
             pass
         if player.color in self.players:
             return False
-        if self.state != GameState.WAITING_PLAYERS:
+        if self.state not in [GameState.WAITING_PLAYERS, GameState.READY_TO_START]:
             return False
 
         self.players[player.color] = player

--- a/app/services/game_service.py
+++ b/app/services/game_service.py
@@ -146,8 +146,8 @@ class GameService:
             raise GameServiceError(f"Tipo de color inesperado: {type(requested_color)}")
 
         async with game.lock: # Asegurar atomicidad al modificar la partida
-            if game.state != GameState.WAITING_PLAYERS:
-                raise GameServiceError("La partida no está esperando jugadores.")
+            if game.state not in [GameState.WAITING_PLAYERS, GameState.READY_TO_START]:
+                raise GameServiceError("La partida no está esperando jugadores o ya ha comenzado.")
             if len(game.players) >= game.max_players:
                 raise GameServiceError("La partida ya está llena.")
             if actual_requested_color_enum in game.players:


### PR DESCRIPTION
Update game state checks to permit player addition when the game is in the READY_TO_START state, enhancing the flexibility of player management.